### PR TITLE
Fix "Saved groups" and "Sessions" not expanding

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -421,7 +421,7 @@ chrome.storage.local.get(function (session_items) {
                     });
                     link_list.classList.add('links');
                     link_list.innerHTML = html;
-                    el.insertBefore(link_list);
+                    el.insertBefore(link_list, null);
                     spoiler.setAttribute('name', 'opened');
                     spoiler.innerHTML = ' &#9660;';
                 },
@@ -741,7 +741,7 @@ chrome.storage.local.get(function (session_items) {
                     });
                     link_list.classList.add('links');
                     link_list.innerHTML = html;
-                    el.insertBefore(link_list);
+                    el.insertBefore(link_list, null);
                     spoiler.setAttribute('name', 'opened');
                     spoiler.innerHTML = ' &#9660;';
                 },


### PR DESCRIPTION
Fix "Saved groups" and "Sessions" not expanding in Opera 25 Developer (on Linux at least)

According to http://javascript.about.com/library/bldom12.htm, insertBefore requires 2 parameters, seting the second parameter to null seems to fix TabHamster for me.

And an additional newline that github seems to have added for me :/
